### PR TITLE
Inject version information to binary

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,0 +1,2 @@
+# include git version
+build --stamp --workspace_status_command internal/version/status.sh

--- a/cmd/apiserver-proxy-sidecar/BUILD
+++ b/cmd/apiserver-proxy-sidecar/BUILD
@@ -38,6 +38,7 @@ go_library(
     visibility = ["//visibility:private"],
     deps = [
         "//internal/app:go_default_library",
+        "//internal/version:go_default_library",
         "@com_github_spf13_pflag//:go_default_library",
         "@io_k8s_klog//:go_default_library",
         "@io_k8s_sigs_controller_runtime//pkg/manager/signals:go_default_library",

--- a/cmd/apiserver-proxy-sidecar/main.go
+++ b/cmd/apiserver-proxy-sidecar/main.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/gardener/apiserver-proxy/internal/app"
+	"github.com/gardener/apiserver-proxy/internal/version"
 	flag "github.com/spf13/pflag"
 	"k8s.io/klog"
 	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
@@ -48,6 +49,12 @@ func parseAndValidateFlags() *app.ConfigParams {
 		"[optional] indicates if the sidecar should run as a daemon")
 	flag.StringVar(&params.IPAddress, "ip-address", "", "ip-address on which the proxy is listening (e.g. 1.2.3.4).")
 	flag.StringVar(&params.LocalPort, "port", "443", "[optional] port on which the proxy is listening.")
+
+	flag.Usage = func() {
+		fmt.Fprintf(os.Stderr, "Usage of %s (%s):\n", os.Args[0], version.Version())
+		flag.PrintDefaults()
+	}
+
 	flag.Parse()
 
 	if params.IPAddress == "" {

--- a/internal/version/BUILD.bazel
+++ b/internal/version/BUILD.bazel
@@ -1,0 +1,12 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["version.go"],
+    importpath = "github.com/gardener/apiserver-proxy/internal/version",
+    visibility = ["//:__subpackages__"],
+    x_defs = {
+        "gitTag": "{STABLE_BUILD_GIT_TAG}",
+        "gitCommit": "{STABLE_BUILD_GIT_COMMIT}",
+    },
+)

--- a/internal/version/status.sh
+++ b/internal/version/status.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+echo STABLE_BUILD_GIT_COMMIT $(git rev-parse HEAD)
+echo STABLE_BUILD_GIT_TAG $(cat VERSION)

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,0 +1,30 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package version
+
+var (
+	gitCommit = ""
+	gitTag    = "v0.0.0-dev"
+)
+
+// Version returs the version in format `{gitTag}-{gitCommit}`
+func Version() string {
+	v := gitTag
+	if gitCommit != "" {
+		v += "-" + gitCommit
+	}
+
+	return v
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

Inject git tag and git commit hash when building / running

**Which issue(s) this PR fixes**:
Fixes # n/a

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
