### PR TITLE
Build arm64 based images

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -41,6 +41,10 @@ apiserver-proxy:
               slack_cfg_name: 'scp_workspace'
         component_descriptor: ~
         publish:
+          oci-builder: docker-buildx
+          platforms:
+          - linux/amd64
+          - linux/arm64
           dockerimages:
             apiserver-proxy:
               tag_as_latest: true


### PR DESCRIPTION
**What this PR does / why we need it**:
Build and publish images for amd64 and arm64.

**Which issue(s) this PR fixes**:
Fixes #11 

**Special notes for your reviewer**:
/cc @ccwienk @DockToFuture 

**Release note**: NONE