### PR TITLE
Build arm64 based images during head-update

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -6,6 +6,10 @@ apiserver-proxy:
       version:
         preprocess: 'inject-commit-hash'
       publish:
+        oci-builder: docker-buildx
+        platforms:
+        - linux/amd64
+        - linux/arm64      
         dockerimages:
           apiserver-proxy:
             registry: 'gcr-readwrite'


### PR DESCRIPTION
What this PR does / why we need it:
Build and publish images for amd64 and arm64 during head-update.

Which issue(s) this PR fixes:
Fixes #11

Special notes for your reviewer:
/cc @ccwienk @DockToFuture

```noteworthy operator
Container images are now being build and published also for `arm64` platforms.
```