### PR TITLE
Change base image of apiserver-proxy-pod-webhook to distroless

### DIFF
--- a/cmd/Dockerfile
+++ b/cmd/Dockerfile
@@ -26,11 +26,9 @@ USER 0:0
 ENTRYPOINT ["/apiserver-proxy-sidecar"]
 
 #############      apiserver-proxy-pod-webhook      #############
-FROM alpine:3.15.4 AS apiserver-proxy-pod-webhook
+FROM gcr.io/distroless/static-debian11:nonroot AS apiserver-proxy-pod-webhook
 
 COPY --from=builder /src/workspace/bazel-bin/cmd/apiserver-proxy-pod-webhook/apiserver-proxy-pod-webhook_/apiserver-proxy-pod-webhook /apiserver-proxy-pod-webhook
 WORKDIR /
-
-USER 0:0
 
 ENTRYPOINT ["/apiserver-proxy-pod-webhook"]


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR changes the base image for `apiserver-proxy-pod-webhook` from `alpine` to [distroless](https://github.com/GoogleContainerTools/distroless). The process will now use a non root user for its execution. This will reduce the attack surface of the image.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
The `apiserver-proxy-pod-webhook` now uses `distroless` instead of `alpine` as a base image.
```
