### PR TITLE
Updated to alpine 3.16 and reworked the container image minimization logic.

### DIFF
--- a/cmd/Dockerfile
+++ b/cmd/Dockerfile
@@ -14,27 +14,38 @@ RUN bazel build --platforms=@io_bazel_rules_go//go/toolchain:linux_$ARCH "//cmd/
 RUN bazel build --platforms=@io_bazel_rules_go//go/toolchain:linux_$ARCH "//cmd/apiserver-proxy-sidecar:apiserver-proxy-sidecar"
 
 #############      apiserver-proxy-builder      #############
-FROM alpine:3.15.4 AS apiserver-proxy-builder
+FROM alpine:3.16.2 AS apiserver-proxy-builder
 
-RUN apk add --no-cache iptables iproute2
+RUN apk add --no-cache iptables iproute2-minimal
 
 WORKDIR /volume
 
 COPY --from=builder /src/workspace/bazel-bin/cmd/apiserver-proxy-sidecar/apiserver-proxy-sidecar_/apiserver-proxy-sidecar ./apiserver-proxy-sidecar
 
-RUN mkdir -p ./sbin ./lib ./usr/lib \
-    && cp -d /lib/ld-musl-* ./lib \
-    && cp -d /lib/libc.musl-* ./lib \
-    && cp -d /lib/libz.so.* ./lib \
-    && cp -d /usr/lib/libelf* ./usr/lib \
-    && cp -d /usr/lib/libip4* ./usr/lib \
-    && cp -d /usr/lib/libip6* ./usr/lib \
-    && cp -d /usr/lib/libxtables* ./usr/lib \
-    && cp -d /usr/lib/libmnl* ./usr/lib \
-    && cp -d /usr/lib/libnftnl* ./usr/lib \
-    && cp -d /sbin/ip ./sbin \
-    && cp -d /sbin/iptables* ./sbin \
-    && cp -d /sbin/xtables* ./sbin
+RUN mkdir -p ./sbin ./lib ./usr/lib ./usr/lib/xtables ./tmp ./run ./etc/iproute2 \
+    && cp -d /lib/ld-musl-* ./lib                                           && echo "package musl" \
+    && cp -d /lib/libc.musl-* ./lib                                         && echo "package musl" \
+    && cp -d /usr/lib/libcap.* ./usr/lib                                    && echo "package libcap" \
+    && cp -d /usr/lib/libpsx.* ./usr/lib                                    && echo "package libcap" \
+    && cp -d /usr/lib/libbz2* ./usr/lib                                     && echo "package libbz2" \
+    && cp -d /usr/lib/libfts* ./usr/lib                                     && echo "package fts" \
+    && cp -d /usr/lib/liblzma* ./usr/lib                                    && echo "package xz-libs" \
+    && cp -d /lib/libz.* ./lib                                              && echo "package zlib" \
+    && cp -d /usr/lib/libasm* ./usr/lib                                     && echo "package libelf" \
+    && cp -d /usr/lib/libdw* ./usr/lib                                      && echo "package libelf" \
+    && cp -d /usr/lib/libelf* ./usr/lib                                     && echo "package libelf" \
+    && cp -d /usr/lib/libmnl.* ./usr/lib                                    && echo "package libmnl" \
+    && cp -d /sbin/ip ./sbin                                                && echo "package iproute2-minimal" \
+    && cp -d /etc/iproute2/* ./etc/iproute2                                 && echo "package iproute2-minimal" \
+    && cp -d /usr/lib/libnftnl* ./usr/lib                                   && echo "package libnftnl" \
+    && cp -d /etc/ethertypes ./etc                                          && echo "package iptables" \
+    && cp -d /sbin/iptables* ./sbin                                         && echo "package iptables" \
+    && cp -d /sbin/xtables* ./sbin                                          && echo "package iptables" \
+    && cp -d /usr/lib/libip4* ./usr/lib                                     && echo "package iptables" \
+    && cp -d /usr/lib/libip6* ./usr/lib                                     && echo "package iptables" \
+    && cp -d /usr/lib/libipq* ./usr/lib                                     && echo "package iptables" \
+    && cp -d /usr/lib/libxtables* ./usr/lib                                 && echo "package iptables" \
+    && cp -d /usr/lib/xtables/* ./usr/lib/xtables                           && echo "package iptables"
 
 #############      apiserver-proxy      #############
 FROM scratch AS apiserver-proxy


### PR DESCRIPTION
**What this PR does / why we need it**:
Updated to alpine 3.16 and reworked the container image minimization logic.

With the update to alpine 3.16 some adjustments were required with regards to dependent libraries. Now, almost all direct/indirect dependencies are included. This should be more stable.

**Which issue(s) this PR fixes**:
None.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Updated base image of apiserver-proxy to alpine 3.16.2
```
