### PR TITLE
Make proxy IPv6 aware

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -29,12 +29,11 @@ func NewSidecarApp(params *ConfigParams) (*SidecarApp, error) {
 	if err != nil {
 		return nil, xerrors.Errorf("unable to parse IP address %q - %v", c.params.IPAddress, err)
 	}
-	
-		addr, err = netlink.ParseAddr(fmt.Sprintf("%s/%d", c.params.IPAddress, ip.BitLen()))
-		if err != nil || addr == nil {
-			return nil, xerrors.Errorf("unable to parse IP address %q - %v", c.params.IPAddress, err)
-		}
-	
+
+	addr, err = netlink.ParseAddr(fmt.Sprintf("%s/%d", c.params.IPAddress, ip.BitLen()))
+	if err != nil || addr == nil {
+		return nil, xerrors.Errorf("unable to parse IP address %q - %v", c.params.IPAddress, err)
+	}
 
 	c.localIP = addr
 

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -29,18 +29,12 @@ func NewSidecarApp(params *ConfigParams) (*SidecarApp, error) {
 	if err != nil {
 		return nil, xerrors.Errorf("unable to parse IP address %q - %v", c.params.IPAddress, err)
 	}
-	if ip.Is4() {
-		addr, err = netlink.ParseAddr(fmt.Sprintf("%s/32", c.params.IPAddress))
+	
+		addr, err = netlink.ParseAddr(fmt.Sprintf("%s/%d", c.params.IPAddress, ip.BitLen()))
 		if err != nil || addr == nil {
 			return nil, xerrors.Errorf("unable to parse IP address %q - %v", c.params.IPAddress, err)
 		}
-	}
-	if ip.Is6() {
-		addr, err = netlink.ParseAddr(fmt.Sprintf("%s/128", c.params.IPAddress))
-		if err != nil || addr == nil {
-			return nil, xerrors.Errorf("unable to parse IP address %q - %v", c.params.IPAddress, err)
-		}
-	}
+	
 
 	c.localIP = addr
 


### PR DESCRIPTION
**What this PR does / why we need it**:
The proxy sidecar gets a IP address and adds `/32` to get a valid CIDR. That works with IPv4 but for IPv6 we need `/128`. 

Now at startup the IP is checked for version 4 or 6 and the right suffix is added.

**Special notes for your reviewer**:
Works together with https://github.com/gardener/gardener/pull/6755

**Release note**:
```improvement operator
Make apiserver proxy sidecar IPv6 aware
```
