### PR TITLE
Update admission version to v1.

### DIFF
--- a/example-webhook.yaml
+++ b/example-webhook.yaml
@@ -4,7 +4,7 @@ metadata:
   name: apiserver-proxy.networking.gardener.cloud
 webhooks:
 - admissionReviewVersions:
-  - v1beta1
+  - v1
   clientConfig:
     caBundle: LS0tLS1C
     url: https://localhost:10250/webhook/pod-apiserver-env

--- a/internal/admission/admission_suite_test.go
+++ b/internal/admission/admission_suite_test.go
@@ -91,7 +91,7 @@ var _ = BeforeSuite(func(done Done) {
 		Name:                    "foo",
 		NamespaceSelector:       &metav1.LabelSelector{},
 		ObjectSelector:          &metav1.LabelSelector{},
-		AdmissionReviewVersions: []string{"v1beta1"},
+		AdmissionReviewVersions: []string{"v1"},
 		Rules: []v1.RuleWithOperations{{
 			Operations: []v1.OperationType{v1.OperationAll},
 			Rule: v1.Rule{


### PR DESCRIPTION
**What this PR does / why we need it**:
Update admission version to v1.

**Which issue(s) this PR fixes**:
None.

**Special notes for your reviewer**:
It looks like this was supported for quite some time already (see https://github.com/gardener/gardener/pull/7547#discussion_r1115731311).

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Use admission v1 instead of v1beta1 for apiserver-proxy webhook.
```
