### PR TITLE
update golang image in verify step to 1.21.3

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -4,7 +4,7 @@ apiserver-proxy:
     repo: ~
     steps:
       verify:
-        image: 'golang:1.21.2'
+        image: 'golang:1.21.3'
     traits:
       component_descriptor:
         component_labels:


### PR DESCRIPTION
**What this PR does / why we need it**:
Update golang image in verify step to 1.21.3.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Update golang image in verify step to 1.21.3.
```
