### PR TITLE
switch GCR -> Artifact-Registry

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -1,7 +1,5 @@
 apiserver-proxy:
-  template: 'default'
   base_definition:
-    repo: ~
     steps:
       verify:
         image: 'golang:1.21.5'
@@ -18,10 +16,9 @@ apiserver-proxy:
         oci-builder: docker-buildx
         platforms:
         - linux/amd64
-        - linux/arm64      
+        - linux/arm64
         dockerimages:
           apiserver-proxy:
-            registry: 'gcr-readwrite'
             image: 'eu.gcr.io/gardener-project/gardener/apiserver-proxy'
             dockerfile: 'cmd/Dockerfile'
             target: apiserver-proxy

--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -5,6 +5,7 @@ apiserver-proxy:
         image: 'golang:1.21.5'
     traits:
       component_descriptor:
+        ocm_repository: europe-docker.pkg.dev/gardener-project/snapshots
         component_labels:
         - name: 'cloud.gardener.cnudie/responsibles'
           value:
@@ -19,7 +20,7 @@ apiserver-proxy:
         - linux/arm64
         dockerimages:
           apiserver-proxy:
-            image: 'eu.gcr.io/gardener-project/gardener/apiserver-proxy'
+            image: europe-docker.pkg.dev/gardener-project/snapshots/gardener/apiserver-proxy
             dockerfile: 'cmd/Dockerfile'
             target: apiserver-proxy
             resource_labels:
@@ -35,6 +36,9 @@ apiserver-proxy:
     head-update:
       traits:
         draft_release: ~
+        component_descriptor:
+          ocm_repository_mappings:
+            - repository: europe-docker.pkg.dev/gardener-project/releases
     pull-request:
       traits:
         pull-request: ~
@@ -44,6 +48,8 @@ apiserver-proxy:
           preprocess: 'finalize'
         release:
           nextversion: 'bump_minor'
+        component_descriptor:
+          ocm_repository: europe-docker.pkg.dev/gardener-project/releases
         slack:
           default_channel: 'internal_scp_workspace'
           channel_cfgs:

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
 # SPDX-License-Identifier: Apache-2.0
 
-REGISTRY                                     := eu.gcr.io/gardener-project/gardener
+REGISTRY                                     := europe-docker.pkg.dev/gardener-project/public/gardener
 APISERVER_PROXY_SIDECAR_IMAGE_REPOSITORY     := $(REGISTRY)/apiserver-proxy
 REPO_ROOT              	                     := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 HACK_DIR                                     := $(REPO_ROOT)/hack


### PR DESCRIPTION
GCR has been deprecated [0] in favour of Artifact-Registry.

Thus, change push-targets for OCI-Images:

- europe-docker.pkg.dev/gardener-project/snapshots for snapshots
- europe-docker.pkg.dev/gardener-project/releases for releases
- europe-docker.pkg.dev/gardener-project/public for combined view of snapshots + releases

[0]
https://cloud.google.com/artifact-registry/docs/transition/transition-from-gcr


**Release note**:

```breaking operator
Change OCI Image Registry from GCR (`eu.gcr.io/gardener-project`) to Artifact-Registry (`europe-docker.pkg.dev/gardener-project/releases`). Users should update their references.

```
