### PR TITLE
Stop the ticker and also document ConfigParams fields

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -45,6 +45,7 @@ func (c *SidecarApp) TeardownNetworking() error {
 
 func (c *SidecarApp) runPeriodic(ctx context.Context) {
 	tick := time.NewTicker(c.params.Interval)
+	defer tick.Stop()
 
 	for {
 		select {

--- a/internal/app/config.go
+++ b/internal/app/config.go
@@ -13,13 +13,20 @@ import (
 
 // ConfigParams lists the configuration options that can be provided to sidecar proxy
 type ConfigParams struct {
-	LocalPort     string        // port to listen for dns requests
-	Interface     string        // Name of the interface to be created
-	Interval      time.Duration // specifies how often to run iptables rules check
-	SetupIptables bool          // enable iptables setup
-	Cleanup       bool          // clean the created interface and iptables
-	Daemon        bool          // run as a daemon
-	IPAddress     string        // IP address on which the proxy is listening
+	// LocalPort specifies the port to listen for DNS requests
+	LocalPort string
+	// Interface specifies the name of the interface to be created
+	Interface string
+	// Interval specifies how often to run iptables rules check
+	Interval time.Duration
+	// SetupIptables enables iptables setup
+	SetupIptables bool
+	// Cleanup specifies whether to clean the created interface and iptables
+	Cleanup bool
+	// Daemon specifies whether to run as daemon
+	Daemon bool
+	// IPAddress specifies the IP address on which the proxy is listening
+	IPAddress string
 }
 
 // SidecarApp contains all the config required to run sidecar proxy.


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR ensures that the created `time.Ticker` is stopped. It also adds proper docstrings to the `ConfigParams` fields.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator

```
