### PR TITLE
add route to local table for non loopback devices

### DIFF
--- a/internal/netif/mocks_test.go
+++ b/internal/netif/mocks_test.go
@@ -124,6 +124,34 @@ func (mr *MockHandleMockRecorder) LinkSetUp(arg0 any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LinkSetUp", reflect.TypeOf((*MockHandle)(nil).LinkSetUp), arg0)
 }
 
+// RouteAdd mocks base method.
+func (m *MockHandle) RouteAdd(route *netlink.Route) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RouteAdd", route)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// RouteAdd indicates an expected call of RouteAdd.
+func (mr *MockHandleMockRecorder) RouteAdd(route any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RouteAdd", reflect.TypeOf((*MockHandle)(nil).RouteAdd), route)
+}
+
+// RouteDel mocks base method.
+func (m *MockHandle) RouteDel(route *netlink.Route) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RouteDel", route)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// RouteDel indicates an expected call of RouteDel.
+func (mr *MockHandleMockRecorder) RouteDel(route any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RouteDel", reflect.TypeOf((*MockHandle)(nil).RouteDel), route)
+}
+
 // MockManager is a mock of Manager interface.
 type MockManager struct {
 	ctrl     *gomock.Controller
@@ -145,6 +173,20 @@ func NewMockManager(ctrl *gomock.Controller) *MockManager {
 // EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockManager) EXPECT() *MockManagerMockRecorder {
 	return m.recorder
+}
+
+// CleanupDevice mocks base method.
+func (m *MockManager) CleanupDevice() error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CleanupDevice")
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// CleanupDevice indicates an expected call of CleanupDevice.
+func (mr *MockManagerMockRecorder) CleanupDevice() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CleanupDevice", reflect.TypeOf((*MockManager)(nil).CleanupDevice))
 }
 
 // EnsureIPAddress mocks base method.

--- a/internal/netif/netif_suite_test.go
+++ b/internal/netif/netif_suite_test.go
@@ -107,6 +107,11 @@ var _ = Describe("Manager", func() {
 
 			It("should return error when deleting ip address", func() {
 				mh.EXPECT().
+					RouteDel(gomock.Any()).
+					Return(nil).
+					Times(1)
+
+				mh.EXPECT().
 					AddrDel(gomock.Eq(dummy), gomock.Eq(addr)).
 					Return(fmt.Errorf("err")).
 					Times(1)
@@ -116,6 +121,10 @@ var _ = Describe("Manager", func() {
 			})
 
 			It("should return already removed error", func() {
+				mh.EXPECT().
+					RouteDel(gomock.Any()).
+					Return(nil).
+					Times(1)
 				mh.EXPECT().
 					AddrDel(gomock.Eq(dummy), gomock.Eq(addr)).
 					// Return(syscall.EEXIST).
@@ -129,6 +138,11 @@ var _ = Describe("Manager", func() {
 			It("should return no error when deleting link", func() {
 				mh.EXPECT().
 					AddrDel(gomock.Eq(dummy), gomock.Eq(addr)).
+					Return(nil).
+					Times(1)
+
+				mh.EXPECT().
+					RouteDel(gomock.Any()).
 					Return(nil).
 					Times(1)
 
@@ -195,6 +209,11 @@ var _ = Describe("Manager", func() {
 					Return(syscall.EEXIST).
 					Times(1)
 
+				mh.EXPECT().
+					RouteAdd(gomock.Any()).
+					Return(nil).
+					Times(1)
+
 				err := manager.EnsureIPAddress()
 				Expect(err).ToNot(HaveOccurred())
 			})
@@ -239,7 +258,10 @@ var _ = Describe("Manager", func() {
 					AddrAdd(gomock.Eq(dummy), gomock.Eq(addr)).
 					Return(syscall.EEXIST).
 					Times(1)
-
+				mh.EXPECT().
+					RouteAdd(gomock.Any()).
+					Return(nil).
+					Times(1)
 				err := manager.EnsureIPAddress()
 				Expect(err).ToNot(HaveOccurred())
 			})
@@ -249,7 +271,10 @@ var _ = Describe("Manager", func() {
 					AddrAdd(gomock.Eq(dummy), gomock.Eq(addr)).
 					Return(nil).
 					Times(1)
-
+				mh.EXPECT().
+					RouteAdd(gomock.Any()).
+					Return(nil).
+					Times(1)
 				err := manager.EnsureIPAddress()
 				Expect(err).ToNot(HaveOccurred())
 			})


### PR DESCRIPTION
**What this PR does / why we need it**:
When introducing the management of network interfaces with #128, using another interface than `lo` in g/g currently results in connectivity issues.
Reason is that loopback devices automatically add routes for IP addresses assigned to it to the local routing table.

This PR creates the needed routes in the local table to ensure routing of the apiserver IP works.
Route is only added when not using the `lo` interface.

**Special notes for your reviewer**: 
The constants used from the golang.org/x/sys/unix package are only visible when GOOS is linux.
For more information see [rtnetlink manpage](https://man7.org/linux/man-pages/man7/rtnetlink.7.html)
