### PR TITLE
allow to build docker image for platform linux/GOARCH

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ build:
 .PHONY: docker-images
 docker-images:
 	@echo "Building docker images with version and tag $(EFFECTIVE_VERSION)"
-	@docker build --build-arg EFFECTIVE_VERSION=$(EFFECTIVE_VERSION) -t $(APISERVER_PROXY_SIDECAR_IMAGE_REPOSITORY):$(EFFECTIVE_VERSION)     -f cmd/Dockerfile --target apiserver-proxy .
+	@docker build --build-arg EFFECTIVE_VERSION=$(EFFECTIVE_VERSION) -t $(APISERVER_PROXY_SIDECAR_IMAGE_REPOSITORY):$(EFFECTIVE_VERSION) --platform=linux/$(GOARCH)    -f cmd/Dockerfile --target apiserver-proxy .
 
 #####################################################################
 # Rules for verification, formatting, linting, testing and cleaning #

--- a/cmd/Dockerfile
+++ b/cmd/Dockerfile
@@ -1,9 +1,10 @@
 #############      builder              #############
-FROM golang:1.23.1 AS builder
+FROM --platform=${BUILDPLATFORM} golang:1.23.1 AS builder
 
 WORKDIR /go/src/github.com/gardener/apiserver-proxy
 COPY . .
 
+ARG BUILDPLATFORM
 ARG TARGETARCH
 ARG EFFECTIVE_VERSION
 


### PR DESCRIPTION
**What this PR does / why we need it**:
use the platform specified by GOARCH in Makefile as the target platform of the docker image. Allows to build amd64 images on an arm64 machine with the Makefile.

**Special notes for your reviewer**:
BUILDPLATFORM runs the build container on the hostplatform and leverages Go's multiplatform build capability to have faster compile times.

