### PR TITLE
Don't set kube-apiserver endpoint address scope to host.

### DIFF
--- a/internal/netif/netif.go
+++ b/internal/netif/netif.go
@@ -39,8 +39,6 @@ type netifManagerDefault struct {
 // NewNetifManager returns a new instance of NetifManager with the ip address set to the provided values
 // These ip addresses will be bound to any devices created by this instance.
 func NewNetifManager(addr *netlink.Addr, devName string) Manager {
-	// Set scope to host only
-	addr.Scope = 0xfe
 
 	return &netifManagerDefault{
 		&netlink.Handle{},

--- a/internal/netif/netif_suite_test.go
+++ b/internal/netif/netif_suite_test.go
@@ -74,9 +74,6 @@ var _ = Describe("Manager", func() {
 				Expect(dm.addr.IPNet).To(Equal(&net.IPNet{IP: net.ParseIP(ip), Mask: net.CIDRMask(32, 32)}))
 			})
 
-			It("should have the correct scope", func() {
-				Expect(dm.addr.Scope).To(Equal(0xfe))
-			})
 		})
 
 		It("should set the correct device name", func() {


### PR DESCRIPTION
Addresses with scope host are not handled during cilium bpf masquerading. As a result packets to that address are send out do the default device.

This should help to fix https://github.com/gardener/gardener-extension-networking-cilium/issues/386
and we would not need https://github.com/gardener/apiserver-proxy/pull/138.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Don't set kube-apiserver endpoint address scope to host to fix cilium bpf masquerading issue.
```
