### PR TITLE
fix: automerge github action updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -28,6 +28,14 @@
       "automerge": true
     },
     {
+      "matchManagers": ["github-actions"],
+      "matchPackagePatterns": [
+        "^actions/checkout$",
+        "^actions/setup-go$",
+      ],
+      "automerge": true
+    },
+    {
       // Ignore paths which most likely create false positives.
       "matchFileNames": [
         "chart/**",


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**What this PR does / why we need it**:
- Enables automatic merging of official github actions like checkout and setup-go (e.g. [here](https://github.com/gardener/apiserver-proxy/pull/251) and [here](https://github.com/gardener/apiserver-proxy/pull/250)
- Avoids manual dev review of these updates

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
